### PR TITLE
Feature/add single shift code redemption support

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -227,11 +227,13 @@ func doShift(client *bl3.Bl3Client, singleShiftCode string) {
 
 func main() {
 	username := ""
+	allowInactive := false
 	password := ""
 	singleShiftCode := ""
 	flag.StringVar(&username, "e", "", "Email")
 	flag.StringVar(&username, "email", "", "Email")
 	flag.StringVar(&password, "p", "", "Password")
+	flag.BoolVar(&allowInactive, "allow-inactive", false, "Attempt to redeem the single SHIFT code even if it is inactive?")
 	flag.StringVar(&password, "password", "", "Password")
 	flag.StringVar(&singleShiftCode, "shift-code", "", "Single SHIFT code to redeem")
 	flag.Parse()
@@ -259,6 +261,8 @@ func main() {
 		printError(err)
 		return
 	}
+
+	client.Config.Shift.AllowInactive = allowInactive
 
 	fmt.Println("success!")
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -11,7 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
-	
+
 	"github.com/shibukawa/configdir"
 	bl3 "github.com/matt1484/bl3_auto_vip"
 )
@@ -134,7 +134,7 @@ func doVip(client *bl3.Bl3Client) {
 	}
 }
 
-func doShift(client *bl3.Bl3Client) {
+func doShift(client *bl3.Bl3Client, singleShiftCode string) {
 	fmt.Print("Getting SHIFT platforms . . . . . ")
 	platforms, err := client.GetShiftPlatforms()
 	if err != nil {
@@ -166,13 +166,28 @@ func doShift(client *bl3.Bl3Client) {
 		fmt.Println("not found.")
 	}
 
-	fmt.Print("Getting new SHIFT codes . . . . . ")
-	shiftCodes, err := client.GetFullShiftCodeList()
-	if err != nil {
-		printError(err)
-		return
+	shiftCodes := bl3.ShiftCodeMap{}
+
+	if singleShiftCode != "" {
+		singleShiftCode = strings.TrimSpace(strings.ToUpper(singleShiftCode))
+		fmt.Print("Checking single SHIFT code '" + singleShiftCode + "' . . . . . ")
+		platforms, valid := client.GetCodePlatforms(singleShiftCode)
+		if valid {
+			shiftCodes[singleShiftCode] = platforms
+			fmt.Println("success!")
+		} else {
+			fmt.Println("no available redemption platforms found!")
+		}
+	} else {
+		fmt.Print("Getting new SHIFT codes . . . . . ")
+		allShiftCodes, err := client.GetFullShiftCodeList()
+		if err != nil {
+			printError(err)
+			return
+		}
+		shiftCodes = allShiftCodes
+		fmt.Println("success!")
 	}
-	fmt.Println("success!")
 
 	foundCodes := false
 	for code, codePlatforms := range shiftCodes {
@@ -196,7 +211,9 @@ func doShift(client *bl3.Bl3Client) {
 		}
 	}
 
-	if !foundCodes {
+	if !foundCodes && singleShiftCode != "" {
+		fmt.Println("The single SHIFT code could not be redeemed at this time. Try again later.")
+	} else if !foundCodes {
 		fmt.Println("No new SHIFT codes at this time. Try again later.")
 	} else {
 		folders := configDirs.QueryFolders(configdir.Global)
@@ -211,10 +228,12 @@ func doShift(client *bl3.Bl3Client) {
 func main() {
 	username := ""
 	password := ""
+	singleShiftCode := ""
 	flag.StringVar(&username, "e", "", "Email")
 	flag.StringVar(&username, "email", "", "Email")
 	flag.StringVar(&password, "p", "", "Password")
 	flag.StringVar(&password, "password", "", "Password")
+	flag.StringVar(&singleShiftCode, "shift-code", "", "Single SHIFT code to redeem")
 	flag.Parse()
 
 	if username == "" {
@@ -255,7 +274,11 @@ func main() {
 	}
 	fmt.Println("success!")
 
-	doShift(client)
-	doVip(client)
+	doShift(client, singleShiftCode)
+
+	if singleShiftCode == "" {
+		doVip(client)
+	}
+
 	exit()
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -227,15 +227,15 @@ func doShift(client *bl3.Bl3Client, singleShiftCode string) {
 
 func main() {
 	username := ""
-	allowInactive := false
 	password := ""
 	singleShiftCode := ""
+	allowInactive := false
 	flag.StringVar(&username, "e", "", "Email")
 	flag.StringVar(&username, "email", "", "Email")
 	flag.StringVar(&password, "p", "", "Password")
-	flag.BoolVar(&allowInactive, "allow-inactive", false, "Attempt to redeem the single SHIFT code even if it is inactive?")
 	flag.StringVar(&password, "password", "", "Password")
 	flag.StringVar(&singleShiftCode, "shift-code", "", "Single SHIFT code to redeem")
+	flag.BoolVar(&allowInactive, "allow-inactive", false, "Attempt to redeem SHIFT codes even if they are inactive?")
 	flag.Parse()
 
 	if username == "" {

--- a/shift.go
+++ b/shift.go
@@ -17,6 +17,7 @@ type ShiftConfig struct {
 	CodeInfoUrl string `json:"codeInfoUrl"`
 	UserInfoUrl string `json:"userInfoUrl"`
 	GameCodename string `json:"gameCodename"`
+	AllowInactive bool
 }
 
 type ShiftCodeMap map[string][]string
@@ -56,7 +57,7 @@ func (client *Bl3Client) GetCodePlatforms(code string) ([]string, bool) {
 	codes := make([]shiftCode, 0)
 	json.From("entitlement_offer_codes").Select("offer_service", "is_active", "offer_title").Out(&codes)
 	for _, code := range codes {
-		if code.Active && code.Game == client.Config.Shift.GameCodename {
+		if (code.Active || client.Config.Shift.AllowInactive) && code.Game == client.Config.Shift.GameCodename {
 			platforms = append(platforms, code.Platform)
 		}
 	}

--- a/shift.go
+++ b/shift.go
@@ -62,6 +62,10 @@ func (client *Bl3Client) GetCodePlatforms(code string) ([]string, bool) {
 		}
 	}
 
+	if len(platforms) == 0 {
+		return platforms, false
+	}
+
 	return platforms, true
 }
 


### PR DESCRIPTION
This PR adds a `-shift-code` parameter that lets you redeem a single SHIFT code. The reason for this is twofold:

1. The user can quickly redeem a SHIFT code that has an expiration time (like the latest BL3 codes) without having to wait for someone to add it to the Orcz.com table (case in point, [this SHIFT code](https://twitter.com/dgShiftCodes/status/1182358424165728262) is 2 hours old, expires in 18 hours, and isn't on Orcz.com yet)
2. Some SHIFT codes aren't flagged as active in the 2K API response, so even if they are on Orcz.com, they won't be redeemed. See below...

I also added an `-allow-inactive` option that allows SHIFT codes to be redeemed even if the 2K API response says they are inactive. For example, the SHIFT code from that tweet above is `5ZC3B-WRKHT-Z53CK-BTB33-CB9HA`, it is active right now, but the 2K API response is:

```json5
{
  "entitlement_offer_codes": [
    // other platforms removed, but all are is_active=false
    {
      "code": "5ZC3B-WRKHT-Z53CK-BTB33-CB9HH",
      "max_redeemable": 1000000,
      "amount_redeemed": 15598,
      "start_date": "2019-10-10T15:00:00.000Z",
      "end_date": "2019-10-11T15:00:00.000Z",
      "offer_title_text": "Golden Key for Borderlands 3",
      "offer_description_text": "Your SHiFT code has been redeemed! Go to your Mail from the in-game Social menu to add the reward to your inventory!",
      "offer_service": "epic",
      "offer_title": "oak",
      "offer_id": 1375,
      "is_active": false
    }
  ]
}
```

**WITHOUT `-allow-inactive`:**

```
❯ go run cmd/main.go -email a@b.com -password abc123 \
  -shift-code "5ZC3B-WRKHT-Z53CK-BTB33-CB9HH"

Setting up . . . . . success!
Logging in as 'a@b.com' . . . . . success!
Getting SHIFT platforms . . . . . success!
Getting previously redeemed SHIFT codes . . . . . success!
Checking single SHIFT code '5ZC3B-WRKHT-Z53CK-BTB33-CB9HH' . . . . . no available redemption platforms found!
The single SHIFT code could not be redeemed at this time. Try again later.
Exiting in 5 4 3 2 1
```

**WITH `-allow-inactive`:**

```
❯ go run cmd/main.go -email a@b.com -password abc123 \
  -shift-code "5ZC3B-WRKHT-Z53CK-BTB33-CB9HH" -allow-inactive

Setting up . . . . . success!
Logging in as 'a@b.com' . . . . . success!
Getting SHIFT platforms . . . . . success!
Getting previously redeemed SHIFT codes . . . . . success!
Checking single SHIFT code '5ZC3B-WRKHT-Z53CK-BTB33-CB9HH' . . . . . success!
Trying 'steam' SHIFT code '5ZC3B-WRKHT-Z53CK-BTB33-CB9HH' . . . . . success!
Trying 'xboxlive' SHIFT code '5ZC3B-WRKHT-Z53CK-BTB33-CB9HH' . . . . . success!
Trying 'psn' SHIFT code '5ZC3B-WRKHT-Z53CK-BTB33-CB9HH' . . . . . success!
Trying 'epic' SHIFT code '5ZC3B-WRKHT-Z53CK-BTB33-CB9HH' . . . . . success!
Trying 'googleplay' SHIFT code '5ZC3B-WRKHT-Z53CK-BTB33-CB9HH' . . . . . success!
Exiting in 5 4 3 2 1
```

This is my first time modifying a go program, but I tried to follow your coding style and conventions. Feel free to fix anything I messed up ;)