### PR TITLE
Add expired SHIFT codes to the redeemed codes array

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -186,6 +186,8 @@ func doShift(client *bl3.Bl3Client) {
 						fmt.Println(err)
 						if strings.Contains(strings.ToLower(err.Error()), "already") {
 							redeemedCodes[code] = append(redeemedCodes[code], platform)
+						} else if strings.Contains(strings.ToLower(err.Error()), "has expired") {
+							redeemedCodes[code] = append(redeemedCodes[code], platform)
 						}
 					} else {
 						redeemedCodes[code] = append(redeemedCodes[code], platform)


### PR DESCRIPTION
When a SHIFT code redemption is attempted, it was added to the redeemed codes array if it was redeemed or if the response was "code already redeemed". This PR adds a check for the response "code has expired" and adds the code to the redeemed codes array. This prevents it from being attempted again.

This is especially useful when looked at in combination with my other PR #25, which adds an `-allow-inactive` option. If you provide only an email, password, and `-allow-inactive`, all of the expired codes on the Orcz.com list are attempted. This PR makes sure that they're only attempted once and then marked as redeemed.