### PR TITLE
Show a message when a single SHIFT code has already been redeemed

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -208,6 +208,9 @@ func doShift(client *bl3.Bl3Client, singleShiftCode string) {
 						redeemedCodes[code] = append(redeemedCodes[code], platform)
 						fmt.Println("success!")
 					}
+				} else if singleShiftCode != "" {
+					fmt.Println("The single SHIFT code has already been redeemed on the '" + platform + "' platform")
+					foundCodes = true
 				}
 			}
 		}


### PR DESCRIPTION
When redeeming a single SHIFT code, if it had already been redeemed on all of the available platforms, the output wasn't clear. This PR adds a message about it having already been redeemed on that platform.

Before: (it makes you think it's an invalid code)

```
Setting up . . . . . success!
Logging in as 'a@b.com' . . . . . success!
Getting SHIFT platforms . . . . . success!
Getting previously redeemed SHIFT codes . . . . . success!
Checking single SHIFT code 'ZFKJ3-TT3BB-JTBJT-T3JJT-JWX9H' . . . . . success!
The single SHIFT code could not be redeemed at this time. Try again later.
Exiting in 5 4 3 2 1
```

After:

```
Setting up . . . . . success!
Logging in as 'a@b.com' . . . . . success!
Getting SHIFT platforms . . . . . success!
Getting previously redeemed SHIFT codes . . . . . success!
Checking single SHIFT code 'ZFKJ3-TT3BB-JTBJT-T3JJT-JWX9H' . . . . . success!
The single SHIFT code has already been redeemed on the 'xboxlive' platform
The single SHIFT code has already been redeemed on the 'psn' platform
The single SHIFT code has already been redeemed on the 'epic' platform
Exiting in 5 4 3 2 1
```