### PR TITLE
Use https://shift.orcicorn.com as the source for active SHIFT codes

### DIFF
--- a/config.json
+++ b/config.json
@@ -23,12 +23,7 @@
         }
     },
     "shiftConfig": {
-        "codeListUrl": "http://orcz.com/Borderlands_3:_Shift_Codes",
-        "codeListRowSelector": ".wikitable tbody tr",
-        "codeListInvalidRegex": "",
-        "codeListCheckIndex": 3,
-        "codeListCodeIndex": 4,
-
+        "codeListUrl": "https://shift.orcicorn.com/tags/borderlands3/index.json",
         "codeInfoUrl": "https://api.2k.com/borderlands/code/",
         "userInfoUrl": "https://api.2k.com/borderlands/users/me",
         "gameCodename": "oak"


### PR DESCRIPTION
This PR changes the source for active SHIFT codes to https://shift.orcicorn.com/tags/borderlands3/index.json - orcz.com tends to always be behind, especially with the limited-time SHIFT codes.

**IMPORTANT:**

[The function `NewBl3Client()` in `client.go`](https://github.com/matt1484/bl3_auto_vip/blob/master/client.go#L124) retrieves the config values from the `master` branch of this repo. The SHIFT code list URL was changed as part of this PR, but it won't be used (until this PR is merged to `master`) unless you change the config URL in that function. You can change it temporarily to the address of this branch in my fork so that it has the necessary change: https://raw.githubusercontent.com/squatto/bl3_auto_vip/feature/use-orcicorn-as-active-shift-code-source/config.json

---

This resolves #30 and #35