### PR TITLE
Remove login redirect b/c the auth process immediately returns the sessionId

### DIFF
--- a/client.go
+++ b/client.go
@@ -165,15 +165,9 @@ func (client *Bl3Client) Login(username string, password string) error {
 		return errors.New("Failed to login")
 	}
 
-	if loginRes.Header.Get(client.Config.LoginRedirectHeader) == "" {
+	if loginRes.Header.Get(client.Config.SessionIdHeader) == "" {
 		return errors.New("Failed to start session")
 	}
-
-	sessionRes, err := client.Get(loginRes.Header.Get(client.Config.LoginRedirectHeader))
-	if err != nil {
-		return errors.New("Failed to get session")
-	}
-	defer sessionRes.Body.Close()
 
 	client.SetDefaultHeader(client.Config.SessionHeader, loginRes.Header.Get(client.Config.SessionIdHeader))
 	return nil


### PR DESCRIPTION
The auth process immediately returns the sessionId instead of redirecting, so we...

1. Check for the sessionId header instead of the login redirect header
2. Remove the GET request to the login redirect URL

The code redemption process will then work:

```
Setting up . . . . . success!
Logging in as '*****@*****.***' . . . . . success!
Getting SHIFT platforms . . . . . success!
Getting previously redeemed SHIFT codes . . . . . not found.
Checking single SHIFT code 'KHWTB-3CBJB-6XWFZ-6B3BB-T5CCJ' . . . . . success!
Trying 'steam' SHIFT code 'KHWTB-3CBJB-6XWFZ-6B3BB-T5CCJ' . . . . . code already redeemed.
Trying 'xboxlive' SHIFT code 'KHWTB-3CBJB-6XWFZ-6B3BB-T5CCJ' . . . . . code already redeemed.
Trying 'psn' SHIFT code 'KHWTB-3CBJB-6XWFZ-6B3BB-T5CCJ' . . . . . code already redeemed.
Trying 'epic' SHIFT code 'KHWTB-3CBJB-6XWFZ-6B3BB-T5CCJ' . . . . . code already redeemed.
Exiting in 5 4 3 2 1
```

I've only tested this with a single code (using the `-shift-code` arg). I haven't tested the rest of the processes yet.